### PR TITLE
Restore compatibility with interface version 120000

### DIFF
--- a/QuestLogCollapse.toc
+++ b/QuestLogCollapse.toc
@@ -1,8 +1,8 @@
-## Interface: 120001
+## Interface: 120000, 120001
 ## Title: QuestLogCollapse
 ## Notes: Automatically collapses the quest log when entering dungeons
 ## Author: Gaspode
-## Version: 1.2.1
+## Version: 1.2.5
 ## SavedVariables: QuestLogCollapseDB
 ## SavedVariablesPerCharacter: QuestLogCollapseCharDB
 


### PR DESCRIPTION
Reintroduce interface version 120000 in the table of contents to ensure compatibility, as the previous method of using future game versions no longer functions correctly.