### PR TITLE
fix: remove ObjectiveTrackerFrame.SetCollapsed cascade from ExpandQuestLog

### DIFF
--- a/QuestLogCollapse.lua
+++ b/QuestLogCollapse.lua
@@ -474,34 +474,6 @@ local function ExpandQuestLog()
         expanded = expanded + 1
     end
 
-    -- Try alternative method for the entire ObjectiveTrackerFrame
-    if ObjectiveTrackerFrame and not InCombatLockdown() then
-        local success, err = pcall(function()
-            if ObjectiveTrackerFrame.SetCollapsed then
-                ObjectiveTrackerFrame:SetCollapsed(false)
-                DebugPrint("ObjectiveTrackerFrame expanded")
-                expanded = expanded + 1
-            end
-
-            -- Also try expanding all modules
-            if ObjectiveTrackerFrame.MODULES then
-                for i, module in ipairs(ObjectiveTrackerFrame.MODULES) do
-                    if module and module.SetCollapsed then
-                        module:SetCollapsed(false)
-                        DebugPrint("Module " .. i .. " expanded")
-                        expanded = expanded + 1
-                    end
-                end
-            end
-        end)
-        
-        if not success then
-            DebugPrint("Failed to expand ObjectiveTrackerFrame: " .. tostring(err))
-        end
-    else
-        DebugPrint("ObjectiveTrackerFrame not found or in combat")
-    end
-
     DebugPrint("Expanded " .. expanded .. " sections/modules")
     
     -- Restore nameplate settings (only if the addon was controlling them)


### PR DESCRIPTION
﻿Closes #23

## Summary

Removes the *"Try alternative method for the entire ObjectiveTrackerFrame"* block from `ExpandQuestLog()`.

This block called `ObjectiveTrackerFrame:SetCollapsed(false)` and then iterated `ObjectiveTrackerFrame.MODULES`, calling `SetCollapsed(false)` on every module — including `UIWidgetObjectiveTracker` and `MonthlyActivitiesObjectiveTracker` — unconditionally, bypassing `TAINT_BLACKLIST` entirely. Those two trackers route `SetCollapsed` through `UIWidgetManager:ProcessWidget → InitPartitions → SetWidth` in a tainted execution context, permanently poisoning pooled `StatusBar` frame widths as secret numbers. The result is hundreds of `LayoutFrame.lua` arithmetic errors per session, persisting until `/reload`.

The block is also **redundant**: each tracker is already expanded individually by `SafeExpandTracker` in the lines immediately above, which respects `TAINT_BLACKLIST`.

## Test plan

- [ ] Enter a dungeon/raid, then leave
- [ ] Confirm objective tracker expands correctly on exit
- [ ] Confirm no `LayoutFrame.lua` errors appear in the error log (`/console scriptErrors 1`)
