### PR TITLE
fix: remove WorldMapFrame:OnShow hook to escape SetPassThroughButtons taint

### DIFF
--- a/QuestLogCollapse.lua
+++ b/QuestLogCollapse.lua
@@ -1152,8 +1152,7 @@ function SlashCmdList.QUESTLOGCOLLAPSE(msg)
         print("")
         print("|cff00ff00Zone Filtering:|r")
         print("• When enabled, zone filtering triggers automatically when you:")
-        print("  - Open the world map")
-        print("  - Open the quest log")
+        print("  - Interact with the quest tracker (minimize/expand)")
         print("  - Start moving after a zone change")
         print("  - Cast any spell/ability (including dynamic flight)")
         print("  - Mount or dismount")
@@ -1360,37 +1359,29 @@ local function TryRunZoneFilter()
     end
 end
 
--- Hook World Map opening (hardware-initiated: key press or mouse click)
--- The world map can be shown through multiple interfaces in modern WoW
-C_Timer.After(1, function()
-    -- WorldMapFrame might not exist immediately, retry until it does
-    local function HookWorldMap()
-        if WorldMapFrame then
-            if not WorldMapFrame.qlcHooked then
-                WorldMapFrame:HookScript("OnShow", function()
-                    DebugPrint("World map opened - checking for pending zone filter")
-                    TryRunZoneFilter()
-                end)
-                WorldMapFrame.qlcHooked = true
-                DebugPrint("Hooked WorldMapFrame for zone filtering")
-            end
-            return true
-        end
-        return false
-    end
-    
-    -- Try hooking immediately
-    if not HookWorldMap() then
-        -- If WorldMapFrame doesn't exist yet, keep trying
-        local attempts = 0
-        local ticker = C_Timer.NewTicker(1, function()
-            attempts = attempts + 1
-            if HookWorldMap() or attempts > 30 then
-                ticker:Cancel()
-            end
-        end)
-    end
-end)
+-- World map open trigger removed.
+--
+-- The previous attempt was a WorldMapFrame:HookScript("OnShow", ...) that
+-- deferred the filter via C_Timer.After(0, TryRunZoneFilter) to escape the
+-- map's protected init chain. The deferral is insufficient because the
+-- OnShow hook BODY itself executes synchronously inside ShowUIPanel →
+-- RefreshAll → secureexecuterange — that's where the addon's Lua frame
+-- enters the call stack and marks the chain tainted. Anything reachable
+-- after that point hits ADDON_ACTION_BLOCKED on Frame:SetPassThroughButtons
+-- / Button:SetPassThroughButtons (BonusObjectiveDataProvider:RefreshAllData,
+-- WorldQuestDataProvider:PingQuestID) on every world-map open.
+--
+-- The hook is removed entirely. Filtering still triggers on movement,
+-- spell/ability cast, mount/dismount, tracker minimize click, and
+-- /qlc filterzone. Convenience cost: filter no longer auto-runs on map
+-- open.
+--
+-- If a map-open trigger is wanted back, RegisterEvent("WORLD_MAP_OPEN") is
+-- the candidate. Per Gethe/wow-ui-source: that event is dispatched as
+-- WorldMapFrame's own OnEvent handler (which itself calls OpenWorldMap →
+-- HandleUserActionOpenSelf → ShowUIPanel), so other registered frames
+-- receive it as a sibling OnEvent dispatch rather than nested inside the
+-- protected init chain. Should be tested in isolation before adding back.
 
 -- Hook Quest Log / Objective Tracker interaction
 C_Timer.After(1, function()
@@ -1427,7 +1418,6 @@ C_Timer.After(1, function()
 end)
 
 DebugPrint("QuestLogCollapse: Zone filtering hooks initialized")
-DebugPrint("  - World map opening will trigger pending filters")
 DebugPrint("  - Quest tracker interaction will trigger pending filters")
 DebugPrint("  - Player movement will trigger pending filters")
 DebugPrint("  - Spell/ability cast will trigger pending filters")

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ QuestLogCollapse/
 
 To avoid taint issues with protected quest tracking functions, zone filtering is triggered by user-initiated actions:
 
-- **World Map Opening** - Automatically triggers when you open the world map
 - **Quest Tracker Interaction** - Triggers when you interact with the objective tracker
 - **Player Movement** - Triggers when you start moving after a zone change
 - **Spell/Ability Use** - Triggers when you cast any spell or ability (including dynamic flight abilities)


### PR DESCRIPTION
## Summary

**Force-pushed an updated approach.** The previous head (`00e5599 fix: defer WorldMapFrame OnShow zone-filter outside protected map init chain`) tried to escape the protected init chain by deferring the filter via `C_Timer.After(0, TryRunZoneFilter)` inside the `OnShow` hook. That deferral is insufficient because **the `OnShow` hook BODY itself executes synchronously inside `ShowUIPanel → RefreshAll → secureexecuterange`** — that's where the addon's Lua frame enters the call stack and marks the chain tainted. Anything reachable after that point hits `ADDON_ACTION_BLOCKED` on `Frame:SetPassThroughButtons` / `Button:SetPassThroughButtons` (`BonusObjectiveDataProvider:RefreshAllData`, `WorldQuestDataProvider:PingQuestID`) on every world-map open.

`C_Timer.After(0, ...)` schedules onto the next frame, but the act of *calling* `C_Timer.After` from inside the secureexecuterange chain is itself the tainting event. The deferral neither prevents that call nor unwinds the stack before it fires.

## What this PR now does

Removes the `WorldMapFrame:HookScript("OnShow", …)` block entirely. Filtering still triggers on:

- Quest tracker minimize/expand interaction
- Player movement (`PLAYER_STARTED_MOVING`)
- Spell/ability cast (`UNIT_SPELLCAST_SUCCEEDED`)
- Mounting/dismounting (`PLAYER_MOUNT_DISPLAY_CHANGED`)
- `/qlc filterzone` slash command

**Convenience cost:** the filter no longer auto-runs on map open. After a zone change, the next user action (movement, spell, mount, tracker click, or slash) picks up the `needsZoneFilter` flag.

## If a map-open trigger is wanted back

`RegisterEvent("WORLD_MAP_OPEN")` is the candidate, not `HookScript("OnShow")`. Per Gethe/wow-ui-source: that event is dispatched as `WorldMapFrame`'s own `OnEvent` handler (which itself calls `OpenWorldMap → HandleUserActionOpenSelf → ShowUIPanel`), so other registered frames receive it as a sibling `OnEvent` dispatch rather than nested inside the protected init chain. Worth testing in isolation before adding back; not part of this PR.

## Files

- `QuestLogCollapse.lua` — hook block removed, slash help text updated
- `README.md` — "World Map Opening" trigger entry removed from the Zone Filtering Triggers list

Closes #25